### PR TITLE
feat: add input validation for EPUB files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Input validation for EPUB files, including ZIP integrity, mimetype, and required structure (container.xml, OPF).
 - Improved navigation UI with a modern sidebar layout for Table of Contents.
 - Navigation controls (Previous/Next) and TOC interaction logic implemented in Python.
 - Automatic navigation button state management (disabling at spine ends).

--- a/src/imposition/book.py
+++ b/src/imposition/book.py
@@ -33,6 +33,16 @@ class Book:
         except zipfile.BadZipFile as e:
             raise InvalidEpubError("The file is not a valid ZIP archive.") from e
 
+        # Validate mimetype file
+        try:
+            mimetype_content: bytes = self.zip_file.read("mimetype")
+            if mimetype_content.strip() != b"application/epub+zip":
+                raise InvalidEpubError(
+                    f"Invalid mimetype: {mimetype_content.decode('utf-8', errors='replace')}"
+                )
+        except KeyError as e:
+            raise InvalidEpubError("mimetype file not found in the EPUB file.") from e
+
         # Find the .opf file from container.xml
         try:
             container_xml: bytes = self.zip_file.read("META-INF/container.xml")

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -119,3 +119,13 @@ def test_spine_item_not_in_manifest():
     })
     with pytest.raises(InvalidEpubError, match="Item in spine not found in manifest"):
         Book(epub_bytes)
+
+def test_missing_mimetype_file():
+    epub_bytes = create_epub_bytes({'META-INF/container.xml': 'some content'})
+    with pytest.raises(InvalidEpubError, match="mimetype file not found"):
+        Book(epub_bytes)
+
+def test_invalid_mimetype_content():
+    epub_bytes = create_epub_bytes({'mimetype': 'text/plain'})
+    with pytest.raises(InvalidEpubError, match="Invalid mimetype: text/plain"):
+        Book(epub_bytes)


### PR DESCRIPTION
Implemented validation in Book.__init__ to:
- Verify the file is a valid ZIP archive.
- Check for the existence and content of the 'mimetype' file.
- Verify the presence of 'META-INF/container.xml'.

Added unit tests to cover missing and invalid 'mimetype' file scenarios. Updated CHANGELOG.md.

Addresses #18.